### PR TITLE
Create website from website

### DIFF
--- a/documentRoot/.htaccess
+++ b/documentRoot/.htaccess
@@ -1,4 +1,0 @@
-AuthType Basic
-AuthName "Restricted Content"
-AuthUserFile /etc/apache2/.htpasswd
-Require valid-user

--- a/documentRoot/restart.php
+++ b/documentRoot/restart.php
@@ -1,3 +1,10 @@
 <?php
+	session_start();
+
+	// Make sure user is logged in
+	if (!isset($_SESSION['username'])){
+		$_SESSION['msg'] = "You must log in first";
+		header('location: index.php');
+	}
 	exec('sudo /sbin/reboot');
 ?>

--- a/documentRoot/websiteUpload.php
+++ b/documentRoot/websiteUpload.php
@@ -31,13 +31,13 @@ if(isset($_POST['submit']))
 		echo " is an improper File type. Must be .zip or .html";
 		header['location: websiteUpload.php'];
 	}
+	//while checksum fails:
+	//	Upload file to new directory
+	//	counter++
+	//	if counter > maxTries
+	//		exit, report error
 
-	//if directory doesn't exist, create it.
-	if(file_exists('/var/userSites/'.escapeshellarg($siteName).'/'))
-	{
-		$_SESSION['msg'] = "That site name is already taken";
-		//header['location: websiteUpload.php'];
-	}
+	//create directory
 	exec('mkdir /var/userSites/'.escapeshellarg($siteName).'/');
 	//Upload file to new directory
 	if(move_uploaded_file($_FILES['siteFile']['tmp_name'], '/var/userSites/'.$siteName.'/'.$name))
@@ -50,11 +50,12 @@ if(isset($_POST['submit']))
 			{
 				$zip->extractTo('/var/userSites/'.$siteName.'/');
 				$zip->close();
-				echo 'unzipping success';
+				//clean up .zip file
+				exec('rm /var/userSites/'.siteName.'/'.$name);
 			}
 			else
 			{
-				echo 'unip failed';
+				echo 'unzip failed';
 			}
 		}
 		else
@@ -65,19 +66,19 @@ if(isset($_POST['submit']))
 	}
 	else
 	{
+		//if something went wrong, remove the directory
 		exec('rmdir /var/userSites/'.escapeshellarg($siteName).'/');
 		echo "There was an issue uploading your file";
 	}
-	//while checksum fails:
-	//	Upload file to new directory
-	//	counter++
-	//	if counter > maxTries
-	//		exit, report error
 		
 	//If site name is a domain name:
 	if($_POST['domain'] == 'true')
 	{
 		//check if valid domain
+		$realIP = file_get_contents("http://ipecho.net/plain");
+		echo $realIP;
+		$givenIP = gethostbyname($siteName);
+		echo $givenIP;
 		//check that domain points to server IP
 		//add entry to sites-available with domain name and document root
 		$confFile = fopen('/etc/apache2/sites-available/'.$siteName.'.conf','w');

--- a/documentRoot/websiteUpload.php
+++ b/documentRoot/websiteUpload.php
@@ -91,6 +91,7 @@ if(isset($_POST['submit']))
 	exec('ln -s /etc/apache2/sites-available/'.$siteName.'.conf /etc/apache2/sites-enabled/'.$siteName.'.conf');
 	
 	//restart apache
+	exec('sudo apache2ctl -k graceful');
 }
 ?>
 
@@ -108,7 +109,9 @@ if(isset($_POST['submit']))
 	<p>Here you can upload files to be hosted as a new website!<br>
 	You can either upload a single html document or a .zip of a website directory<br>
 	If you have a domain name for your website, it will be hosted there. <br>
-	Otherwise just give your site a name and it'll be hosted at "this_ip/websitename"</p>
+	Otherwise just give your site a name and it'll be hosted at "this_ip/websitename"<br>
+	<br>
+	If you are uploading a .zip make sure that the page you want a visitor to see first is called "index.html" or any other web accessible file extension.<br></p>
 	<!-- Form -->
 	<form action="websiteUpload.php" method="post" enctype="multipart/form-data">
 		Select File to Upload:

--- a/documentRoot/websiteUpload.php
+++ b/documentRoot/websiteUpload.php
@@ -26,9 +26,7 @@ if(isset($_POST['submit']))
 	if(!($type == "application/zip" || $type == "text/html"))
 	{
 		//exit, report error
-		echo $type;
-		echo " is an improper File type. Must be .zip or .html";
-		header['location: websiteUpload.php'];
+		die($type." Is not a valid file type. Must be either .html or .zip");
 	}
 	
 	//If site name is a domain name:
@@ -37,6 +35,7 @@ if(isset($_POST['submit']))
 		//check if valid domain
 		$realIP = file_get_contents("http://ipecho.net/plain");
 		$givenIP = gethostbyname($siteName);
+
 		//check that domain points to server IP
 		if($givenIP != $realIP)
 		{
@@ -50,7 +49,7 @@ if(isset($_POST['submit']))
 	//	if counter > maxTries
 	//		exit, report error
 
-	//FALUIRES SHOULD NOT OCCUER AFTER THIS POINT
+	//FALUIRES SHOULD NOT OCCUR AFTER THIS POINT
 	//DO ALL ERROR CHECKING ABOVE HERE
 	
 	//create directory

--- a/documentRoot/websiteUpload.php
+++ b/documentRoot/websiteUpload.php
@@ -19,4 +19,34 @@
 //	counter++
 //	if counter > maxTries
 //		exit, report error
+//
+//If there is a domain name:
+//	check if valid domain
+//	check that domain points to server IP
+//	add entry to sites-available with domain name and document root
+//	add soft link from sites-enabled to sites-available entry
+//else:
+//	add alias to apache2.conf to ip/sitename
+//
+//restart apache
 ?>
+
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Website Upload | Pi In The Sky</title>
+	<link rel="stylesheet" type="text/css" href="/css/style.css">
+</head>
+<body>
+	<div class="header">
+		<h2>Website Upload<h2>
+	</div>
+	<div class="content">
+	<p>Here you can upload files to be hosted as a new website!<br>
+	You can either upload a single html document or a .zip of a website directory<br>
+	If you have a domain name for your website, it will be hosted there. <br>
+	Otherwise just give your site a name and it'll be hosted at "this_ip/websitename"</p>
+	<!-- Form -->
+	<div>
+</body>
+</html>

--- a/documentRoot/websiteUpload.php
+++ b/documentRoot/websiteUpload.php
@@ -1,34 +1,51 @@
 <?php
 //If not coming from submit page:
-//	report error, exit
-//
-//get file name
-//get file tmpName
-//get file type
-//get file size
-//
-//if type is not an allowable type:
-//	exit, report error
-//
-//if size > MAXFILESIZE:
-//	exit, report error
-//
-//Upload file to new directory
-//while checksum fails:
-//	Upload file to new directory
-//	counter++
-//	if counter > maxTries
-//		exit, report error
-//
-//If there is a domain name:
-//	check if valid domain
-//	check that domain points to server IP
-//	add entry to sites-available with domain name and document root
-//	add soft link from sites-enabled to sites-available entry
-//else:
-//	add alias to apache2.conf to ip/sitename
-//
-//restart apache
+//	go to login page
+session_start();
+if (!isset($_SESSION['username']))
+{
+	$_SESSION['msg'] = "You must log in first";
+	header{'location: index.php'};
+}
+
+
+if(isset($_POST['submit']))
+{
+	//get file name
+	//get file tmpName
+	//get file type
+	//get file size
+	$name = $_FILES['siteFile']['name'];
+	$tmpName = $_FILES['siteFile']['tmp_name'];
+	$type = $_FILES['siteFile']['type'];
+	$size = $_FILES['siteFile']['size'];
+
+	
+	//if type is not an allowable type:
+	if(!($type == ".zip" || $type == ".html"))
+	{
+		//exit, report error
+		echo "Improper File type. Must be .zip or .html";
+		header{'location: websiteUpload.php'}
+	}
+
+
+	//Upload file to new directory
+	//while checksum fails:
+	//	Upload file to new directory
+	//	counter++
+	//	if counter > maxTries
+	//		exit, report error
+	//
+	//If there is a domain name:
+	//	check if valid domain
+	//	check that domain points to server IP
+	//	add entry to sites-available with domain name and document root
+	//	add soft link from sites-enabled to sites-available entry
+	//else:
+	//	add alias to apache2.conf to ip/sitename
+	//
+	//restart apache
 ?>
 
 <!DOCTYPE html>

--- a/documentRoot/websiteUpload.php
+++ b/documentRoot/websiteUpload.php
@@ -90,9 +90,14 @@ if(isset($_POST['submit']))
 		fwrite($confFile,"\n");
 		fwrite($confFile,"  ErrorLog /var/log/apache2/".$siteName."_error.log");
 		fwrite($confFile,"\n");
-		fwrite($confFile,"  Require all granted");
+		fwrite($confFile,"  <Directory />");
+		fwrite($confFile,"\n");
+		fwrite($confFile,"    Require all granted");
+		fwrite($confFile,"\n");
+		fwrite($confFile,"  </Directory>");
 		fwrite($confFile,"\n");
 		fwrite($confFile,"</VirtualHost>");
+		fclose($confFile);
 	}
 	else
 	{

--- a/documentRoot/websiteUpload.php
+++ b/documentRoot/websiteUpload.php
@@ -70,7 +70,17 @@ if(isset($_POST['submit']))
 		//check if valid domain
 		//check that domain points to server IP
 		//add entry to sites-available with domain name and document root
-		//add soft link from sites-enabled to sites-available entry
+		$confFile = fopen('/etc/apache2/sites-available/'.$siteName.'.conf','w');
+		fwrite($confFile,"<VirtualHost *:80>\n");
+		fwrite($confFile,"  ServerName ".$siteName);
+		fwrite($confFile,"\n");
+		fwrite($confFile,"  ServerAlias www.".$siteName);
+		fwrite($confFile,"\n");
+		fwrite($confFile,"  DocumentRoot /var/userSites/".$siteName."/");
+		fwrite($confFile,"\n");
+		fwrite($confFile,"  ErrorLog ${APACHE_LOG_DIR}/".$siteName."_error.log");
+		fwrite($confFile,"\n");
+		fwrite($confFile,"</VirtualHost>");
 	}
 	else
 	{

--- a/documentRoot/websiteUpload.php
+++ b/documentRoot/websiteUpload.php
@@ -76,9 +76,15 @@ if(isset($_POST['submit']))
 	{
 		//check if valid domain
 		$realIP = file_get_contents("http://ipecho.net/plain");
-		echo $realIP;
 		$givenIP = gethostbyname($siteName);
-		echo $givenIP;
+		if($givenIP == 0);
+		{
+			die("That domain name is not valid");
+		}
+		if($givenIP != $realIP)
+		{
+			die("That domain does not point to this server");
+		}
 		//check that domain points to server IP
 		//add entry to sites-available with domain name and document root
 		$confFile = fopen('/etc/apache2/sites-available/'.$siteName.'.conf','w');

--- a/documentRoot/websiteUpload.php
+++ b/documentRoot/websiteUpload.php
@@ -21,7 +21,7 @@ if(isset($_POST['submit']))
 	$size = $_FILES['siteFile']['size'];
 	//get site name
 	$siteName = $_POST['siteName'];
-
+	echo $siteName;
 	
 	//if type is not an allowable type:
 	if(!($type == "application/zip" || $type == "text/html"))
@@ -33,17 +33,17 @@ if(isset($_POST['submit']))
 
 
 	//Upload file to new directory
-	exec('mkdir /var/userSites/$siteName/');
-	if(move_uploaded_file($_FILES['siteFile']['tmp_name'], '/var/www/$siteName/'))
+	exec('mkdir /var/userSites/'.escapeshellarg($siteName).'/');
+	if(move_uploaded_file($_FILES['siteFile']['tmp_name'], '/var/userSites/'.$siteName.'/'.$name))
 	{
 		if($type == "application/zip")
 		{
-			exec('unzip /var/www/$sitename/$name');
+			exec('unzip /var/www/'.escapeshellarg($sitename).'/'.escapeshellarg($name));
 		}
 	}
 	else
 	{
-		exec('rmdir /var/userSites/$siteName/');
+		exec('rmdir /var/userSites/'.escapeshellarg($siteName).'/');
 		echo "There was an issue uploading your file";
 	}
 	//while checksum fails:
@@ -52,14 +52,21 @@ if(isset($_POST['submit']))
 	//	if counter > maxTries
 	//		exit, report error
 		
-	//If there is a domain name:
-	//	check if valid domain
-	//	check that domain points to server IP
-	//	add entry to sites-available with domain name and document root
-	//	add soft link from sites-enabled to sites-available entry
-	//else:
-	//	add alias to apache2.conf to ip/sitename
-	//
+	//If site name is a domain name:
+	if($_POST['domain'] == 'true')
+	{
+		//check if valid domain
+		//check that domain points to server IP
+		//add entry to sites-available with domain name and document root
+		//add soft link from sites-enabled to sites-available entry
+	}
+	else
+	{
+		//add directory and alias to new sites-available conf file
+	}
+
+	//soft link sites available to sites enabled
+	//exec('ln -s /etc/apache2/sites-available/$siteName.conf /etc/apache2/sites-enabled/$siteName.conf')
 	
 	//restart apache
 }

--- a/documentRoot/websiteUpload.php
+++ b/documentRoot/websiteUpload.php
@@ -8,7 +8,7 @@ if (!isset($_SESSION['username']))
 	header['location: index.php'];
 }
 
-
+//once button is clicked
 if(isset($_POST['submit']))
 {
 	//get file name
@@ -21,7 +21,6 @@ if(isset($_POST['submit']))
 	$size = $_FILES['siteFile']['size'];
 	//get site name
 	$siteName = $_POST['siteName'];
-	echo $siteName;
 	
 	//if type is not an allowable type:
 	if(!($type == "application/zip" || $type == "text/html"))
@@ -31,12 +30,29 @@ if(isset($_POST['submit']))
 		echo " is an improper File type. Must be .zip or .html";
 		header['location: websiteUpload.php'];
 	}
+	
+	//If site name is a domain name:
+	if($_POST['domain'] == 'true')
+	{
+		//check if valid domain
+		$realIP = file_get_contents("http://ipecho.net/plain");
+		$givenIP = gethostbyname($siteName);
+		//check that domain points to server IP
+		if($givenIP != $realIP)
+		{
+			die("That domain does not point to this server");
+		}
+	}
+
 	//while checksum fails:
 	//	Upload file to new directory
 	//	counter++
 	//	if counter > maxTries
 	//		exit, report error
 
+	//FALUIRES SHOULD NOT OCCUER AFTER THIS POINT
+	//DO ALL ERROR CHECKING ABOVE HERE
+	
 	//create directory
 	exec('mkdir /var/userSites/'.escapeshellarg($siteName).'/');
 	//Upload file to new directory
@@ -50,8 +66,6 @@ if(isset($_POST['submit']))
 			{
 				$zip->extractTo('/var/userSites/'.$siteName.'/');
 				$zip->close();
-				//clean up .zip file
-				exec('rm /var/userSites/'.siteName.'/'.$name);
 			}
 			else
 			{
@@ -74,18 +88,6 @@ if(isset($_POST['submit']))
 	//If site name is a domain name:
 	if($_POST['domain'] == 'true')
 	{
-		//check if valid domain
-		$realIP = file_get_contents("http://ipecho.net/plain");
-		$givenIP = gethostbyname($siteName);
-		if($givenIP == 0);
-		{
-			die("That domain name is not valid");
-		}
-		if($givenIP != $realIP)
-		{
-			die("That domain does not point to this server");
-		}
-		//check that domain points to server IP
 		//add entry to sites-available with domain name and document root
 		$confFile = fopen('/etc/apache2/sites-available/'.$siteName.'.conf','w');
 		fwrite($confFile,"<VirtualHost *:80>\n");

--- a/documentRoot/websiteUpload.php
+++ b/documentRoot/websiteUpload.php
@@ -33,7 +33,7 @@ if(isset($_POST['submit']))
 
 
 	//Upload file to new directory
-	exec('mkdir /var/www/$siteName/');
+	exec('mkdir /var/userSites/$siteName/');
 	if(move_uploaded_file($_FILES['siteFile']['tmp_name'], '/var/www/$siteName/'))
 	{
 		if($type == "application/zip")
@@ -43,7 +43,7 @@ if(isset($_POST['submit']))
 	}
 	else
 	{
-		exec('rmdir /var/www/$siteName/');
+		exec('rmdir /var/userSites/$siteName/');
 		echo "There was an issue uploading your file";
 	}
 	//while checksum fails:
@@ -84,6 +84,8 @@ if(isset($_POST['submit']))
 	<form action="websiteUpload.php" method="post" enctype="multipart/form-data">
 		Select File to Upload:
 		Site name:<input type="text" name="siteName"><br>
+		Is this a domain name?<br>
+		<input type="radio" name="domain" value="true">Yes<br>
 		<input type="file" name="siteFile" id="siteFile"><br>
 		<input type="submit" value="Upload File" name="submit">
 	</form>

--- a/documentRoot/websiteUpload.php
+++ b/documentRoot/websiteUpload.php
@@ -45,7 +45,17 @@ if(isset($_POST['submit']))
 		//unzip zipped files
 		if($type == "application/zip")
 		{
-			exec('unzip /var/www/'.escapeshellarg($sitename).'/'.escapeshellarg($name));
+			$zip = new ZipArchive;
+			if($zip->open('/var/userSites/'.$siteName.'/'.$name))
+			{
+				$zip->extractTo('/var/userSites/'.$siteName.'/');
+				$zip->close();
+				echo 'unzipping success';
+			}
+			else
+			{
+				echo 'unip failed';
+			}
 		}
 		else
 		{
@@ -78,7 +88,9 @@ if(isset($_POST['submit']))
 		fwrite($confFile,"\n");
 		fwrite($confFile,"  DocumentRoot /var/userSites/".$siteName."/");
 		fwrite($confFile,"\n");
-		fwrite($confFile,"  ErrorLog ${APACHE_LOG_DIR}/".$siteName."_error.log");
+		fwrite($confFile,"  ErrorLog /var/log/apache2/".$siteName."_error.log");
+		fwrite($confFile,"\n");
+		fwrite($confFile,"  Require all granted");
 		fwrite($confFile,"\n");
 		fwrite($confFile,"</VirtualHost>");
 	}

--- a/documentRoot/websiteUpload.php
+++ b/documentRoot/websiteUpload.php
@@ -1,0 +1,22 @@
+<?php
+//If not coming from submit page:
+//	report error, exit
+//
+//get file name
+//get file tmpName
+//get file type
+//get file size
+//
+//if type is not an allowable type:
+//	exit, report error
+//
+//if size > MAXFILESIZE:
+//	exit, report error
+//
+//Upload file to new directory
+//while checksum fails:
+//	Upload file to new directory
+//	counter++
+//	if counter > maxTries
+//		exit, report error
+?>

--- a/documentRoot/websiteUpload.php
+++ b/documentRoot/websiteUpload.php
@@ -5,38 +5,53 @@ session_start();
 if (!isset($_SESSION['username']))
 {
 	$_SESSION['msg'] = "You must log in first";
-	header{'location: index.php'};
+	header['location: index.php'];
 }
 
 
 if(isset($_POST['submit']))
 {
 	//get file name
-	//get file tmpName
-	//get file type
-	//get file size
 	$name = $_FILES['siteFile']['name'];
+	//get file tmpName
 	$tmpName = $_FILES['siteFile']['tmp_name'];
+	//get file type
 	$type = $_FILES['siteFile']['type'];
+	//get file size
 	$size = $_FILES['siteFile']['size'];
+	//get site name
+	$siteName = $_POST['siteName'];
 
 	
 	//if type is not an allowable type:
-	if(!($type == ".zip" || $type == ".html"))
+	if(!($type == "application/zip" || $type == "text/html"))
 	{
 		//exit, report error
-		echo "Improper File type. Must be .zip or .html";
-		header{'location: websiteUpload.php'}
+		echo $type;
+		echo " is an improper File type. Must be .zip or .html";
 	}
 
 
 	//Upload file to new directory
+	exec('mkdir /var/www/$siteName/');
+	if(move_uploaded_file($_FILES['siteFile']['tmp_name'], '/var/www/$siteName/'))
+	{
+		if($type == "application/zip")
+		{
+			exec('unzip /var/www/$sitename/$name');
+		}
+	}
+	else
+	{
+		exec('rmdir /var/www/$siteName/');
+		echo "There was an issue uploading your file";
+	}
 	//while checksum fails:
 	//	Upload file to new directory
 	//	counter++
 	//	if counter > maxTries
 	//		exit, report error
-	//
+		
 	//If there is a domain name:
 	//	check if valid domain
 	//	check that domain points to server IP
@@ -45,7 +60,9 @@ if(isset($_POST['submit']))
 	//else:
 	//	add alias to apache2.conf to ip/sitename
 	//
+	
 	//restart apache
+}
 ?>
 
 <!DOCTYPE html>
@@ -64,6 +81,13 @@ if(isset($_POST['submit']))
 	If you have a domain name for your website, it will be hosted there. <br>
 	Otherwise just give your site a name and it'll be hosted at "this_ip/websitename"</p>
 	<!-- Form -->
+	<form action="websiteUpload.php" method="post" enctype="multipart/form-data">
+		Select File to Upload:
+		Site name:<input type="text" name="siteName"><br>
+		<input type="file" name="siteFile" id="siteFile"><br>
+		<input type="submit" value="Upload File" name="submit">
+	</form>
+
 	<div>
 </body>
 </html>

--- a/gitScripts/gitToApache.sh
+++ b/gitScripts/gitToApache.sh
@@ -37,6 +37,7 @@ else
 	echo "cleaning apache/htdocs"
 	cd $DOCUMENTROOT
 	rm -rf *
+	rm .*.swp
 
 	echo "Unpacking"
 	mv $REPOROOT/documentRoot.tar ./


### PR DESCRIPTION
Added ability for users to create websites from the admin page.
Users can either upload a single .hmtl document or a .zip archive of their desired document root.
Users can specify if they want the site hosted under a separate domain, or as a sub-page of the admin page.

Next steps:
Better HTML form, incorporating JS syntax checking of user input
Ability to enable/disable and delete user sites.